### PR TITLE
Handle time data type

### DIFF
--- a/compressedfhir/utilities/fhir_json_encoder.py
+++ b/compressedfhir/utilities/fhir_json_encoder.py
@@ -40,7 +40,7 @@ class FhirJSONEncoder(json.JSONEncoder):
             return o.isoformat()
 
         if hasattr(o, "to_dict"):
-            return o.dict()
+            return o.to_dict()
 
         # New type handlers
 

--- a/compressedfhir/utilities/fhir_json_encoder.py
+++ b/compressedfhir/utilities/fhir_json_encoder.py
@@ -1,30 +1,71 @@
 import dataclasses
 import json
-from datetime import datetime, date
+import uuid
+from datetime import datetime, date, time
 from decimal import Decimal
 from enum import Enum
+from pathlib import Path
 from typing import Any
+
+# Optional: Import for additional type support
+try:
+    import ipaddress
+except ImportError:
+    ipaddress = None  # type:ignore[assignment]
 
 
 class FhirJSONEncoder(json.JSONEncoder):
     def default(self, o: Any) -> Any:
+        # Existing type handlers
         if dataclasses.is_dataclass(o):
             return dataclasses.asdict(o)  # type:ignore
+
         if isinstance(o, Enum):
             return o.value
+
         if isinstance(o, Decimal):
             # Custom Decimal conversion
             if o == o.to_integral_value():
-                # If Decimal is a whole number, return as int
                 return int(o)
             else:
-                # If Decimal has a non-zero decimal part, return as float
                 return float(o)
+
         if isinstance(o, bytes):
             return o.decode("utf-8")
+
         if isinstance(o, (datetime, date)):
             return o.isoformat()
+
+        if isinstance(o, time):
+            return o.isoformat()
+
         if hasattr(o, "to_dict"):
             return o.dict()
+
+        # New type handlers
+
+        # UUID handling
+        if isinstance(o, uuid.UUID):
+            return str(o)
+
+        # Set and frozenset handling
+        if isinstance(o, (set, frozenset)):
+            return list(o)
+
+        # Complex number handling
+        if isinstance(o, complex):
+            return {"real": o.real, "imag": o.imag}
+
+        # Path-like objects
+        if isinstance(o, (Path, Path)):
+            return str(o)
+
+        # IP Address handling (if ipaddress module is available)
+        if ipaddress and isinstance(o, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
+            return str(o)
+
+        # Custom object serialization fallback
+        if hasattr(o, "__dict__"):
+            return o.__dict__
 
         return super().default(o)

--- a/compressedfhir/utilities/test/test_fhir_json_encoder.py
+++ b/compressedfhir/utilities/test/test_fhir_json_encoder.py
@@ -1,0 +1,177 @@
+import dataclasses
+import json
+import uuid
+from datetime import datetime, date, time
+from decimal import Decimal
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from compressedfhir.utilities.fhir_json_encoder import FhirJSONEncoder
+
+# Optional: Import for additional type support
+try:
+    import ipaddress
+except ImportError:
+    ipaddress = None  # type:ignore[assignment]
+
+
+# Test support classes and enums
+class TestEnum(Enum):
+    OPTION1 = "value1"
+    OPTION2 = "value2"
+
+
+@dataclasses.dataclass
+class TestDataclass:
+    name: str
+    age: int
+    optional_field: Optional[str] = None
+
+
+class TestClassWithToDict:
+    # noinspection PyMethodMayBeStatic
+    def to_dict(self) -> dict[str, str]:
+        return {"key": "value"}
+
+
+def test_fhir_json_encoder_dataclass() -> None:
+    """Test serialization of dataclass"""
+    test_obj = TestDataclass(name="John", age=30)
+    encoded = json.dumps(test_obj, cls=FhirJSONEncoder)
+    decoded = json.loads(encoded)
+
+    assert decoded == {"name": "John", "age": 30, "optional_field": None}
+
+
+def test_fhir_json_encoder_enum() -> None:
+    """Test serialization of Enum"""
+    encoded = json.dumps(TestEnum.OPTION1, cls=FhirJSONEncoder)
+    assert encoded == '"value1"'
+
+
+def test_fhir_json_encoder_decimal() -> None:
+    """Test Decimal conversion"""
+    # Whole number Decimal
+    whole_decimal = Decimal("10")
+    encoded_whole = json.dumps(whole_decimal, cls=FhirJSONEncoder)
+    assert encoded_whole == "10"
+
+    # Decimal with fractional part
+    frac_decimal = Decimal("10.5")
+    encoded_frac = json.dumps(frac_decimal, cls=FhirJSONEncoder)
+    assert encoded_frac == "10.5"
+
+
+def test_fhir_json_encoder_bytes() -> None:
+    """Test bytes conversion"""
+    test_bytes = b"hello world"
+    encoded = json.dumps(test_bytes, cls=FhirJSONEncoder)
+    assert encoded == '"hello world"'
+
+
+def test_fhir_json_encoder_datetime() -> None:
+    """Test datetime serialization"""
+    test_datetime = datetime(2023, 1, 15, 12, 30, 45)
+    encoded = json.dumps(test_datetime, cls=FhirJSONEncoder)
+    assert encoded == '"2023-01-15T12:30:45"'
+
+
+def test_fhir_json_encoder_date() -> None:
+    """Test date serialization"""
+    test_date = date(2023, 1, 15)
+    encoded = json.dumps(test_date, cls=FhirJSONEncoder)
+    assert encoded == '"2023-01-15"'
+
+
+def test_fhir_json_encoder_time() -> None:
+    """Test time serialization"""
+    test_time = time(12, 30, 45)
+    encoded = json.dumps(test_time, cls=FhirJSONEncoder)
+    assert encoded == '"12:30:45"'
+
+
+def test_fhir_json_encoder_to_dict() -> None:
+    """Test objects with to_dict method"""
+    test_obj = TestClassWithToDict()
+    encoded = json.dumps(test_obj, cls=FhirJSONEncoder)
+    assert encoded == '{"key": "value"}'
+
+
+def test_fhir_json_encoder_unsupported_type() -> None:
+    """Test fallback for unsupported types"""
+
+    class UnsupportedType:
+        pass
+
+    with pytest.raises(TypeError):
+        json.dumps(UnsupportedType(), cls=FhirJSONEncoder)
+
+
+def test_extended_json_encoder_uuid() -> None:
+    """Test UUID serialization"""
+    test_uuid = uuid.uuid4()
+    encoded = json.dumps(test_uuid, cls=FhirJSONEncoder)
+    assert isinstance(json.loads(encoded), str)
+    assert len(json.loads(encoded)) == 36  # Standard UUID string length
+
+
+def test_extended_json_encoder_set() -> None:
+    """Test set and frozenset serialization"""
+    test_set = {1, 2, 3}
+    test_frozenset = frozenset([4, 5, 6])
+
+    encoded_set = json.dumps(test_set, cls=FhirJSONEncoder)
+    encoded_frozenset = json.dumps(test_frozenset, cls=FhirJSONEncoder)
+
+    decoded_set = json.loads(encoded_set)
+    decoded_frozenset = json.loads(encoded_frozenset)
+
+    assert set(decoded_set) == test_set
+    assert set(decoded_frozenset) == test_frozenset
+
+
+def test_extended_json_encoder_complex() -> None:
+    """Test complex number serialization"""
+    test_complex = 3 + 4j
+    encoded = json.dumps(test_complex, cls=FhirJSONEncoder)
+    decoded = json.loads(encoded)
+
+    assert decoded == {"real": 3.0, "imag": 4.0}
+
+
+def test_extended_json_encoder_path() -> None:
+    """Test Path object serialization"""
+    test_path = Path("/test/path")
+    encoded = json.dumps(test_path, cls=FhirJSONEncoder)
+    assert json.loads(encoded) == str(test_path)
+
+
+def test_extended_json_encoder_ip_address() -> None:
+    """Test IP Address serialization (if ipaddress module is available)"""
+    if ipaddress:
+        ipv4 = ipaddress.IPv4Address("192.168.0.1")
+        ipv6 = ipaddress.IPv6Address("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+
+        encoded_ipv4 = json.dumps(ipv4, cls=FhirJSONEncoder)
+        encoded_ipv6 = json.dumps(ipv6, cls=FhirJSONEncoder)
+
+        assert json.loads(encoded_ipv4) == str(ipv4)
+        assert json.loads(encoded_ipv6) == str(ipv6)
+
+
+def test_extended_json_encoder_custom_object() -> None:
+    """Test custom object serialization"""
+
+    class CustomObject:
+        def __init__(self) -> None:
+            self.x = 1
+            self.y = 2
+
+    obj = CustomObject()
+    encoded = json.dumps(obj, cls=FhirJSONEncoder)
+    decoded = json.loads(encoded)
+
+    assert decoded == {"x": 1, "y": 2}

--- a/compressedfhir/utilities/test/test_fhir_json_encoder.py
+++ b/compressedfhir/utilities/test/test_fhir_json_encoder.py
@@ -5,7 +5,7 @@ from datetime import datetime, date, time
 from decimal import Decimal
 from enum import Enum
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
 
 import pytest
 
@@ -104,7 +104,7 @@ def test_fhir_json_encoder_unsupported_type() -> None:
     """Test fallback for unsupported types"""
 
     class UnsupportedType:
-        pass
+        __slots__: List[str] = []
 
     with pytest.raises(TypeError):
         json.dumps(UnsupportedType(), cls=FhirJSONEncoder)

--- a/compressedfhir/utilities/test/test_json_helpers.py
+++ b/compressedfhir/utilities/test/test_json_helpers.py
@@ -1,0 +1,99 @@
+import json
+from datetime import datetime, date
+from typing import List, Dict, Any
+
+from compressedfhir.utilities.json_helpers import FhirClientJsonHelpers
+
+
+class TestFhirClientJsonHelpers:
+    def test_json_serial(self) -> None:
+        # Test datetime serialization
+        dt = datetime(2023, 1, 15, 12, 30)
+        assert FhirClientJsonHelpers.json_serial(dt) == "2023-01-15T12:30:00"
+
+        # Test date serialization
+        d = date(2023, 1, 15)
+        assert FhirClientJsonHelpers.json_serial(d) == "2023-01-15"
+
+        # Test other types
+        assert FhirClientJsonHelpers.json_serial(123) == "123"
+        assert FhirClientJsonHelpers.json_serial("test") == "test"
+
+    def test_remove_empty_elements(self) -> None:
+        # Test dictionary removal
+        input_dict = {"a": 1, "b": "", "c": None, "d": [], "e": {}, "f": [1, 2, 3]}
+        expected_dict = {"a": 1, "f": [1, 2, 3]}
+        assert FhirClientJsonHelpers.remove_empty_elements(input_dict) == expected_dict
+
+        # Test list of dictionaries
+        input_list: List[Dict[str, Any]] = [
+            {"a": 1, "b": None},
+            {"c": [], "d": "test"},
+            {"e": {}},
+        ]
+        expected_list: List[Dict[str, Any]] = [{"a": 1}, {"d": "test"}]
+        assert FhirClientJsonHelpers.remove_empty_elements(input_list) == expected_list
+
+    def test_remove_empty_elements_from_ordered_dict(self) -> None:
+        from collections import OrderedDict
+
+        # Test OrderedDict removal
+        input_dict = OrderedDict(
+            [("a", 1), ("b", ""), ("c", None), ("d", []), ("e", {}), ("f", [1, 2, 3])]
+        )
+        expected_dict = OrderedDict([("a", 1), ("f", [1, 2, 3])])
+        result: List[OrderedDict[str, Any]] | OrderedDict[str, Any] = (
+            FhirClientJsonHelpers.remove_empty_elements_from_ordered_dict(input_dict)
+        )
+        assert result == expected_dict
+
+        # Test list of OrderedDicts
+        input_list: List[OrderedDict[str, Any]] = [
+            OrderedDict([("a", 1), ("b", None)]),
+            OrderedDict([("c", []), ("d", "test")]),
+            OrderedDict([("e", {})]),
+        ]
+        expected_list: List[OrderedDict[str, Any]] = [
+            OrderedDict([("a", 1)]),
+            OrderedDict([("d", "test")]),
+        ]
+        result = FhirClientJsonHelpers.remove_empty_elements_from_ordered_dict(
+            input_list
+        )
+        assert result == expected_list
+
+    def test_convert_dict_to_fhir_json(self) -> None:
+        input_dict = {"name": "John Doe", "age": 30, "address": None, "hobbies": []}
+        result = FhirClientJsonHelpers.convert_dict_to_fhir_json(input_dict)
+        parsed_result = json.loads(result)
+        assert parsed_result == {"name": "John Doe", "age": 30}
+
+    def test_orjson_dumps(self) -> None:
+        # Test basic serialization
+        data = {"a": 1, "b": "test"}
+        result = FhirClientJsonHelpers.orjson_dumps(data)
+        assert json.loads(result) == data
+
+        # Test sorting keys
+        result_sorted = FhirClientJsonHelpers.orjson_dumps(data, sort_keys=True)
+        assert result_sorted == '{"a":1,"b":"test"}'
+
+        # Test indentation (limited support)
+        result_indent = FhirClientJsonHelpers.orjson_dumps(data, indent=2)
+        assert isinstance(result_indent, str)
+
+    def test_orjson_loads(self) -> None:
+        # Test string input
+        json_str = '{"a": 1, "b": "test"}'
+        result = FhirClientJsonHelpers.orjson_loads(json_str)
+        assert result == {"a": 1, "b": "test"}
+
+        # Test bytes input
+        json_bytes = b'{"a": 1, "b": "test"}'
+        result = FhirClientJsonHelpers.orjson_loads(json_bytes)
+        assert result == {"a": 1, "b": "test"}
+
+        # Test invalid JSON
+        invalid_json = "{invalid json}"
+        result = FhirClientJsonHelpers.orjson_loads(invalid_json)
+        assert result is None


### PR DESCRIPTION
1. Comprehensive type handling: The new `FhirJSONEncoder` now supports a wide range of Python types, including:
   - UUIDs
   - Sets and frozensets
   - Complex numbers
   - Path-like objects
   - IP Addresses (with optional support)
   - Custom objects with `__dict__`

2. Robust error handling: The encoder falls back to different serialization strategies and raises a `TypeError` for truly unsupported types.

3. Extensive test coverage: The test file `test_fhir_json_encoder.py` provides thorough testing for each type of serialization.

Suggestions and Observations:
1. Optional Dependency Handling: The code uses a try-except block for the `ipaddress` module, which is a good practice for optional dependencies.

2. Decimal Conversion: The Decimal conversion logic is clean and handles both whole numbers and fractional numbers appropriately.

3. Time Serialization: Added support for `time` objects, which was previously missing.