### PR TITLE
refactor: remove OrderedDict usage in CompressedDict and related classes

### DIFF
--- a/compressedfhir/fhir/fhir_bundle.py
+++ b/compressedfhir/fhir/fhir_bundle.py
@@ -1,6 +1,6 @@
 import copy
 import json
-from typing import Any, Dict, List, Optional, cast, OrderedDict
+from typing import Any, Dict, List, Optional, cast
 
 from compressedfhir.fhir.fhir_bundle_entry import FhirBundleEntry
 from compressedfhir.fhir.fhir_bundle_entry_list import FhirBundleEntryList
@@ -13,9 +13,6 @@ from compressedfhir.utilities.compressed_dict.v1.compressed_dict_storage_mode im
 )
 from compressedfhir.utilities.fhir_json_encoder import FhirJSONEncoder
 from compressedfhir.utilities.json_helpers import FhirClientJsonHelpers
-from compressedfhir.utilities.ordered_dict_to_dict_converter.ordered_dict_to_dict_converter import (
-    OrderedDictToDictConverter,
-)
 
 
 class FhirBundle:
@@ -68,13 +65,11 @@ class FhirBundle:
         self.link: Optional[List[FhirLink]] = link
         self.meta: Optional[FhirMeta] = meta
 
-    def dict(self) -> OrderedDict[str, Any]:
+    def dict(self) -> Dict[str, Any]:
         entries: List[Dict[str, Any]] | None = (
             [entry.dict() for entry in self.entry] if self.entry else None
         )
-        result: OrderedDict[str, Any] = OrderedDict[str, Any](
-            {"type": self.type_, "resourceType": "Bundle"}
-        )
+        result: Dict[str, Any] = {"type": self.type_, "resourceType": "Bundle"}
 
         if self.id_ is not None:
             result["id"] = self.id_
@@ -90,7 +85,7 @@ class FhirBundle:
             result["link"] = [link.dict() for link in self.link]
         if self.meta:
             result["meta"] = self.meta.dict()
-        return FhirClientJsonHelpers.remove_empty_elements_from_ordered_dict(result)
+        return FhirClientJsonHelpers.remove_empty_elements(result)
 
     @classmethod
     def construct(
@@ -131,7 +126,7 @@ class FhirBundle:
     @classmethod
     def from_dict(
         cls,
-        data: OrderedDict[str, Any] | Dict[str, Any],
+        data: Dict[str, Any],
         storage_mode: CompressedDictStorageMode | None = None,
     ) -> "FhirBundle":
         """
@@ -292,4 +287,4 @@ class FhirBundle:
 
         :return: Plain dictionary representation of the Bundle
         """
-        return OrderedDictToDictConverter.convert(self.dict())
+        return self.dict()

--- a/compressedfhir/fhir/fhir_bundle_entry.py
+++ b/compressedfhir/fhir/fhir_bundle_entry.py
@@ -1,6 +1,6 @@
 import copy
 import json
-from typing import Any, Dict, Optional, List, OrderedDict
+from typing import Any, Dict, Optional, List
 
 from compressedfhir.fhir.fhir_bundle_entry_search import FhirBundleEntrySearch
 from compressedfhir.fhir.fhir_link import FhirLink
@@ -39,7 +39,7 @@ class FhirBundleEntry:
         self,
         *,
         fullUrl: Optional[str] = None,
-        resource: Dict[str, Any] | FhirResource | OrderedDict[str, Any] | None,
+        resource: Dict[str, Any] | FhirResource | None,
         request: Optional[FhirBundleEntryRequest] = None,
         response: Optional[FhirBundleEntryResponse] = None,
         link: Optional[List[FhirLink]] = None,
@@ -79,7 +79,7 @@ class FhirBundleEntry:
         cls,
         *,
         fullUrl: Optional[str] = None,
-        resource: Dict[str, Any] | FhirResource | OrderedDict[str, Any] | None,
+        resource: Dict[str, Any] | FhirResource | None,
         request: Optional[FhirBundleEntryRequest] = None,
         response: Optional[FhirBundleEntryResponse] = None,
         link: Optional[List[FhirLink]] = None,
@@ -138,8 +138,8 @@ class FhirBundleEntry:
         else:
             self._resource = None
 
-    def dict(self) -> OrderedDict[str, Any]:
-        result: OrderedDict[str, Any] = OrderedDict[str, Any]()
+    def dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
         if self.fullUrl is not None:
             result["fullUrl"] = self.fullUrl
         if self.resource is not None:
@@ -152,12 +152,12 @@ class FhirBundleEntry:
             result["link"] = [link.dict() for link in self.link]
         if self.search is not None:
             result["search"] = self.search.dict()
-        return FhirClientJsonHelpers.remove_empty_elements_from_ordered_dict(result)
+        return FhirClientJsonHelpers.remove_empty_elements(result)
 
     @classmethod
     def from_dict(
         cls,
-        d: OrderedDict[str, Any] | Dict[str, Any],
+        d: Dict[str, Any],
         storage_mode: CompressedDictStorageMode | None = None,
     ) -> "FhirBundleEntry":
         if storage_mode is None:

--- a/compressedfhir/fhir/fhir_bundle_entry_request.py
+++ b/compressedfhir/fhir/fhir_bundle_entry_request.py
@@ -38,9 +38,7 @@ class FhirBundleEntryRequest:
         return FhirClientJsonHelpers.remove_empty_elements(result)
 
     @classmethod
-    def from_dict(
-        cls, d: Dict[str, Any]
-    ) -> "FhirBundleEntryRequest":
+    def from_dict(cls, d: Dict[str, Any]) -> "FhirBundleEntryRequest":
         date_if_modified_since: Optional[datetime] = None
         if "ifModifiedSince" in d:
             if isinstance(d["ifModifiedSince"], datetime):

--- a/compressedfhir/fhir/fhir_bundle_entry_request.py
+++ b/compressedfhir/fhir/fhir_bundle_entry_request.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, Optional, OrderedDict
+from typing import Any, Dict, Optional
 
 from compressedfhir.utilities.json_helpers import FhirClientJsonHelpers
 
@@ -27,21 +27,19 @@ class FhirBundleEntryRequest:
         self.ifNoneMatch: Optional[str] = ifNoneMatch
         self.ifNoneExist: Optional[str] = ifNoneExist
 
-    def dict(self) -> OrderedDict[str, Any]:
-        result: OrderedDict[str, Any] = OrderedDict[str, Any](
-            {"url": self.url, "method": self.method}
-        )
+    def dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {"url": self.url, "method": self.method}
         if self.ifModifiedSince is not None:
             result["ifModifiedSince"] = self.ifModifiedSince.isoformat()
         if self.ifNoneMatch is not None:
             result["ifNoneMatch"] = self.ifNoneMatch
         if self.ifNoneExist is not None:
             result["ifNoneExist"] = self.ifNoneExist
-        return FhirClientJsonHelpers.remove_empty_elements_from_ordered_dict(result)
+        return FhirClientJsonHelpers.remove_empty_elements(result)
 
     @classmethod
     def from_dict(
-        cls, d: Dict[str, Any] | OrderedDict[str, Any]
+        cls, d: Dict[str, Any]
     ) -> "FhirBundleEntryRequest":
         date_if_modified_since: Optional[datetime] = None
         if "ifModifiedSince" in d:

--- a/compressedfhir/fhir/fhir_bundle_entry_response.py
+++ b/compressedfhir/fhir/fhir_bundle_entry_response.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, Optional, OrderedDict
+from typing import Any, Dict, Optional
 
 from compressedfhir.utilities.json_helpers import FhirClientJsonHelpers
 
@@ -27,19 +27,19 @@ class FhirBundleEntryResponse:
         self.etag: Optional[str] = etag
         self.location: Optional[str] = location
 
-    def dict(self) -> OrderedDict[str, Any]:
-        result: OrderedDict[str, Any] = OrderedDict[str, Any]({"status": self.status})
+    def dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {"status": self.status}
         if self.lastModified is not None:
             result["lastModified"] = self.lastModified.isoformat()
         if self.etag is not None:
             result["etag"] = self.etag
         if self.location is not None:
             result["location"] = self.location
-        return FhirClientJsonHelpers.remove_empty_elements_from_ordered_dict(result)
+        return FhirClientJsonHelpers.remove_empty_elements(result)
 
     @classmethod
     def from_dict(
-        cls, d: Dict[str, Any] | OrderedDict[str, Any]
+        cls, d: Dict[str, Any]
     ) -> "FhirBundleEntryResponse":
         date_last_modified: Optional[datetime] = None
         if "lastModified" in d:

--- a/compressedfhir/fhir/fhir_bundle_entry_response.py
+++ b/compressedfhir/fhir/fhir_bundle_entry_response.py
@@ -38,9 +38,7 @@ class FhirBundleEntryResponse:
         return FhirClientJsonHelpers.remove_empty_elements(result)
 
     @classmethod
-    def from_dict(
-        cls, d: Dict[str, Any]
-    ) -> "FhirBundleEntryResponse":
+    def from_dict(cls, d: Dict[str, Any]) -> "FhirBundleEntryResponse":
         date_last_modified: Optional[datetime] = None
         if "lastModified" in d:
             if isinstance(d["lastModified"], datetime):

--- a/compressedfhir/fhir/fhir_bundle_entry_search.py
+++ b/compressedfhir/fhir/fhir_bundle_entry_search.py
@@ -36,9 +36,7 @@ class FhirBundleEntrySearch:
         return FhirClientJsonHelpers.remove_empty_elements(result)
 
     @classmethod
-    def from_dict(
-        cls, data: Dict[str, Any]
-    ) -> "FhirBundleEntrySearch":
+    def from_dict(cls, data: Dict[str, Any]) -> "FhirBundleEntrySearch":
         """
         Creates a FhirBundleEntrySearch object from a dictionary.
 

--- a/compressedfhir/fhir/fhir_bundle_entry_search.py
+++ b/compressedfhir/fhir/fhir_bundle_entry_search.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional, Dict, Any, OrderedDict
+from typing import Optional, Dict, Any
 
 from compressedfhir.utilities.fhir_json_encoder import FhirJSONEncoder
 from compressedfhir.utilities.json_helpers import FhirClientJsonHelpers
@@ -21,23 +21,23 @@ class FhirBundleEntrySearch:
         self.mode: Optional[str] = mode
         self.score: Optional[float] = score
 
-    def dict(self) -> OrderedDict[str, Any]:
+    def dict(self) -> Dict[str, Any]:
         """
         Converts the FhirBundleEntrySearch instance to a dictionary.
 
         :return: A dictionary representation of the FhirBundleEntrySearch instance.
         """
-        result: OrderedDict[str, Any] = OrderedDict[str, Any]()
+        result: Dict[str, Any] = {}
         if self.mode is not None:
             result["mode"] = self.mode
         if self.score is not None:
             result["score"] = self.score
 
-        return FhirClientJsonHelpers.remove_empty_elements_from_ordered_dict(result)
+        return FhirClientJsonHelpers.remove_empty_elements(result)
 
     @classmethod
     def from_dict(
-        cls, data: Dict[str, Any] | OrderedDict[str, Any]
+        cls, data: Dict[str, Any]
     ) -> "FhirBundleEntrySearch":
         """
         Creates a FhirBundleEntrySearch object from a dictionary.

--- a/compressedfhir/fhir/fhir_identifier.py
+++ b/compressedfhir/fhir/fhir_identifier.py
@@ -44,9 +44,7 @@ class FhirIdentifier:
         return FhirClientJsonHelpers.remove_empty_elements(result)
 
     @classmethod
-    def from_dict(
-        cls, data: Dict[str, Any]
-    ) -> "FhirIdentifier":
+    def from_dict(cls, data: Dict[str, Any]) -> "FhirIdentifier":
         """
         Create a FhirIdentifier object from a dictionary.
 

--- a/compressedfhir/fhir/fhir_identifier.py
+++ b/compressedfhir/fhir/fhir_identifier.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional, Dict, Any, OrderedDict
+from typing import Optional, Dict, Any
 
 from compressedfhir.utilities.json_helpers import FhirClientJsonHelpers
 
@@ -28,24 +28,24 @@ class FhirIdentifier:
         self.system: Optional[str] = system
         self.value: Optional[str] = value
 
-    def dict(self) -> OrderedDict[str, Any]:
+    def dict(self) -> Dict[str, Any]:
         """
         Convert the FhirIdentifier object to a dictionary.
 
         :return: A dictionary representation of the FhirIdentifier object.
         """
-        result: OrderedDict[str, Any] = OrderedDict[str, Any]()
+        result: Dict[str, Any] = {}
         if self.use is not None:
             result["use"] = self.use
         if self.system is not None:
             result["system"] = self.system
         if self.value is not None:
             result["value"] = self.value
-        return FhirClientJsonHelpers.remove_empty_elements_from_ordered_dict(result)
+        return FhirClientJsonHelpers.remove_empty_elements(result)
 
     @classmethod
     def from_dict(
-        cls, data: Dict[str, Any] | OrderedDict[str, Any]
+        cls, data: Dict[str, Any]
     ) -> "FhirIdentifier":
         """
         Create a FhirIdentifier object from a dictionary.

--- a/compressedfhir/fhir/fhir_link.py
+++ b/compressedfhir/fhir/fhir_link.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, OrderedDict
+from typing import Any, Dict
 
 from compressedfhir.utilities.fhir_json_encoder import FhirJSONEncoder
 from compressedfhir.utilities.json_helpers import FhirClientJsonHelpers
@@ -22,14 +22,14 @@ class FhirLink:
         self.url: str = url
         self.relation: str = relation
 
-    def dict(self) -> OrderedDict[str, Any]:
+    def dict(self) -> Dict[str, Any]:
         """
         Converts the FhirLink instance to a dictionary.
 
         :return: A dictionary representation of the link.
         """
-        result = OrderedDict[str, Any]({"url": self.url, "relation": self.relation})
-        return FhirClientJsonHelpers.remove_empty_elements_from_ordered_dict(result)
+        result: Dict[str, Any] = {"url": self.url, "relation": self.relation}
+        return FhirClientJsonHelpers.remove_empty_elements(result)
 
     def json(self) -> str:
         """
@@ -43,7 +43,7 @@ class FhirLink:
         return f"FhirLink(url={self.url}, relation={self.relation})"
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any] | OrderedDict[str, Any]) -> "FhirLink":
+    def from_dict(cls, data: Dict[str, Any]) -> "FhirLink":
         """
         Populates the FhirLink instance from a dictionary.
 

--- a/compressedfhir/fhir/fhir_meta.py
+++ b/compressedfhir/fhir/fhir_meta.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, Dict, OrderedDict
+from typing import Any, Dict
 
 from compressedfhir.utilities.json_helpers import FhirClientJsonHelpers
 
@@ -17,8 +17,8 @@ class FhirMeta:
     security: list[Dict[str, Any]] | None = None
     tag: list[str] | None = None
 
-    def dict(self) -> OrderedDict[str, Any]:
-        result: OrderedDict[str, Any] = OrderedDict[str, Any]()
+    def dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
         if self.version_id is not None:
             result["versionId"] = self.version_id
         if self.last_updated is not None:
@@ -33,7 +33,7 @@ class FhirMeta:
             ]
         if self.tag is not None:
             result["tag"] = [t for t in self.tag if t]
-        return FhirClientJsonHelpers.remove_empty_elements_from_ordered_dict(result)
+        return FhirClientJsonHelpers.remove_empty_elements(result)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "FhirMeta":

--- a/compressedfhir/fhir/fhir_resource.py
+++ b/compressedfhir/fhir/fhir_resource.py
@@ -1,6 +1,6 @@
 import copy
 import json
-from typing import Any, Optional, Dict, List, cast, OrderedDict, override
+from typing import Any, Optional, Dict, List, cast, override
 
 from compressedfhir.fhir.fhir_meta import FhirMeta
 from compressedfhir.utilities.compressed_dict.v1.compressed_dict import (
@@ -22,7 +22,7 @@ class FhirResource(CompressedDict[str, Any]):
 
     def __init__(
         self,
-        initial_dict: Dict[str, Any] | OrderedDict[str, Any] | None = None,
+        initial_dict: Dict[str, Any] | None = None,
         *,
         meta: Optional[FhirMeta] = None,
         storage_mode: CompressedDictStorageMode | None = None,
@@ -154,11 +154,9 @@ class FhirResource(CompressedDict[str, Any]):
         """Convert the resource to a JSON string."""
 
         # working_dict preserves the python types so create a fhir friendly version
-        raw_dict: OrderedDict[str, Any] = self.raw_dict()
+        raw_dict: Dict[str, Any] = self.raw_dict()
 
-        raw_dict = FhirClientJsonHelpers.remove_empty_elements_from_ordered_dict(
-            raw_dict
-        )
+        raw_dict = FhirClientJsonHelpers.remove_empty_elements(raw_dict)
         return json.dumps(obj=raw_dict, cls=FhirJSONEncoder)
 
     def to_fhir_dict(self) -> Dict[str, Any]:

--- a/compressedfhir/fhir/fhir_resource_map.py
+++ b/compressedfhir/fhir/fhir_resource_map.py
@@ -8,7 +8,6 @@ from typing import (
     Generator,
     List,
     Tuple,
-    OrderedDict,
 )
 
 from compressedfhir.fhir.fhir_resource_list import FhirResourceList
@@ -36,12 +35,12 @@ class FhirResourceMap:
         """
         self._resource_map: Dict[str, FhirResourceList] = initial_dict or {}
 
-    def dict(self) -> OrderedDict[str, Any]:
+    def dict(self) -> Dict[str, Any]:
         """
         Convert the FhirResourceMap to a dictionary representation.
 
         """
-        result: OrderedDict[str, Any] = OrderedDict[str, Any]()
+        result: Dict[str, Any] = {}
         for key, value in self._resource_map.items():
             result[key] = [resource.dict() for resource in value]
         return result

--- a/compressedfhir/fhir/test/test_fhir_resource.py
+++ b/compressedfhir/fhir/test/test_fhir_resource.py
@@ -1,4 +1,5 @@
 import json
+from collections import OrderedDict
 from typing import Dict, Any
 
 from compressedfhir.fhir.fhir_resource import FhirResource
@@ -102,3 +103,49 @@ class TestFhirResource:
         assert parsed_json == initial_data
         assert "resourceType" in parsed_json
         assert "id" in parsed_json
+
+    def test_accepts_ordered_dict_input(self) -> None:
+        """Test that FhirResource still accepts OrderedDict as input for backward compatibility."""
+        ordered_data: OrderedDict[str, Any] = OrderedDict()
+        ordered_data["resourceType"] = "Patient"
+        ordered_data["id"] = "123"
+        ordered_data["name"] = [{"given": ["John"]}]
+
+        resource = FhirResource(
+            initial_dict=ordered_data, storage_mode=CompressedDictStorageMode()
+        )
+
+        with resource.transaction():
+            assert resource.resource_type == "Patient"
+            assert resource.id == "123"
+
+    def test_dict_returns_regular_dict(self) -> None:
+        """Test that dict() returns a regular dict (not OrderedDict) but preserves order."""
+        initial_data: Dict[str, Any] = {
+            "resourceType": "Patient",
+            "id": "123",
+        }
+        resource = FhirResource(
+            initial_dict=initial_data, storage_mode=CompressedDictStorageMode()
+        )
+
+        result = resource.dict()
+
+        # Should be a dict, not OrderedDict
+        assert type(result) is dict
+        # Order should be preserved
+        assert list(result.keys()) == ["resourceType", "id"]
+
+    def test_from_dict_accepts_ordered_dict(self) -> None:
+        """Test that from_dict accepts OrderedDict for backward compatibility."""
+        ordered_data: OrderedDict[str, Any] = OrderedDict()
+        ordered_data["resourceType"] = "Observation"
+        ordered_data["id"] = "456"
+
+        resource = FhirResource.from_dict(
+            ordered_data, storage_mode=CompressedDictStorageMode()
+        )
+
+        assert resource.resource_type == "Observation"
+        assert resource.id == "456"
+

--- a/compressedfhir/fhir/test/test_fhir_resource.py
+++ b/compressedfhir/fhir/test/test_fhir_resource.py
@@ -148,4 +148,3 @@ class TestFhirResource:
 
         assert resource.resource_type == "Observation"
         assert resource.id == "456"
-

--- a/compressedfhir/utilities/compressed_dict/v1/compressed_dict.py
+++ b/compressedfhir/utilities/compressed_dict/v1/compressed_dict.py
@@ -2,7 +2,7 @@ import copy
 import json
 from collections.abc import KeysView, ValuesView, ItemsView, MutableMapping
 from contextlib import contextmanager
-from typing import Dict, Optional, Iterator, cast, List, Any, overload, OrderedDict
+from typing import Dict, Optional, Iterator, cast, List, Any, overload
 
 import msgpack
 import zlib
@@ -17,9 +17,6 @@ from compressedfhir.utilities.compressed_dict.v1.compressed_dict_storage_mode im
 from compressedfhir.utilities.fhir_json_encoder import FhirJSONEncoder
 from compressedfhir.utilities.json_serializers.type_preservation_serializer import (
     TypePreservationSerializer,
-)
-from compressedfhir.utilities.ordered_dict_to_dict_converter.ordered_dict_to_dict_converter import (
-    OrderedDictToDictConverter,
 )
 
 
@@ -45,7 +42,7 @@ class CompressedDict[K, V](MutableMapping[K, V]):
     def __init__(
         self,
         *,
-        initial_dict: Dict[K, V] | OrderedDict[K, V] | None = None,
+        initial_dict: Dict[K, V] | None = None,
         storage_mode: CompressedDictStorageMode,
         properties_to_cache: List[K] | None,
     ) -> None:
@@ -62,10 +59,10 @@ class CompressedDict[K, V](MutableMapping[K, V]):
         self._storage_mode: CompressedDictStorageMode = storage_mode
 
         # Working copy of the dictionary during context
-        self._working_dict: Optional[OrderedDict[K, V]] = None
+        self._working_dict: Optional[Dict[K, V]] = None
 
         # Private storage options
-        self._raw_dict: OrderedDict[K, V] = OrderedDict[K, V]()
+        self._raw_dict: Dict[K, V] = {}
         self._serialized_dict: Optional[bytes] = None
 
         self._properties_to_cache: List[K] | None = properties_to_cache
@@ -76,15 +73,9 @@ class CompressedDict[K, V](MutableMapping[K, V]):
 
         self._transaction_depth: int = 0
 
-        # Populate initial dictionary if provided
+        # Populate the initial dictionary if provided
         if initial_dict:
-            # Ensure we use an OrderedDict to maintain original order
-            initial_dict_ordered = (
-                initial_dict
-                if isinstance(initial_dict, OrderedDict)
-                else OrderedDict[K, V](initial_dict)
-            )
-            self.replace(value=initial_dict_ordered)
+            self.replace(value=initial_dict)
 
     @contextmanager
     def transaction(self) -> Iterator["CompressedDict[K, V]"]:
@@ -112,7 +103,7 @@ class CompressedDict[K, V](MutableMapping[K, V]):
         """
         # Increment transaction depth
         self._transaction_depth += 1
-        # Ensure working dictionary is ready on first entry
+        # Ensure a working dictionary is ready on first entry
         if self._transaction_depth == 1:
             self.ensure_working_dict()
 
@@ -142,8 +133,8 @@ class CompressedDict[K, V](MutableMapping[K, V]):
         if not self._working_dict:
             self._working_dict = self.create_working_dict()
 
-    def create_working_dict(self) -> OrderedDict[K, V]:
-        working_dict: OrderedDict[K, V]
+    def create_working_dict(self) -> Dict[K, V]:
+        working_dict: Dict[K, V]
         # Deserialize the dictionary before entering the context
         if self._storage_mode.storage_type == "raw":
             # For raw mode, create a deep copy of the existing dictionary
@@ -156,17 +147,16 @@ class CompressedDict[K, V](MutableMapping[K, V]):
                     storage_type=self._storage_mode.storage_type,
                 )
                 if self._serialized_dict
-                else OrderedDict[K, V]()
+                else {}
             )
-            assert isinstance(working_dict, OrderedDict)
         return working_dict
 
     @staticmethod
     def _serialize_dict(
-        *, dictionary: OrderedDict[K, V], storage_type: CompressedDictStorageType
+        *, dictionary: Dict[K, V], storage_type: CompressedDictStorageType
     ) -> bytes:
         """
-        Serialize entire dictionary using MessagePack
+        Serialize the entire dictionary using MessagePack
 
         Args:
             dictionary: Dictionary to serialize
@@ -175,7 +165,6 @@ class CompressedDict[K, V](MutableMapping[K, V]):
         Returns:
             Serialized bytes
         """
-        assert isinstance(dictionary, OrderedDict)
         if storage_type == "compressed":
             # Serialize to JSON and compress with zlib
             json_str = TypePreservationSerializer.serialize(dictionary)
@@ -201,7 +190,7 @@ class CompressedDict[K, V](MutableMapping[K, V]):
         *,
         serialized_dict_bytes: bytes,
         storage_type: CompressedDictStorageType,
-    ) -> OrderedDict[K, V]:
+    ) -> Dict[K, V]:
         """
         Deserialize entire dictionary from MessagePack
 
@@ -219,9 +208,10 @@ class CompressedDict[K, V](MutableMapping[K, V]):
             decompressed_bytes: bytes = zlib.decompress(serialized_dict_bytes)
             decoded_text: str = decompressed_bytes.decode("utf-8")
             # noinspection PyTypeChecker
-            decompressed_dict = TypePreservationSerializer.deserialize(decoded_text)
-            assert isinstance(decompressed_dict, OrderedDict)
-            return cast(OrderedDict[K, V], decompressed_dict)
+            decompressed_dict = TypePreservationSerializer.deserialize(
+                decoded_text, use_ordered_dict=False
+            )
+            return cast(Dict[K, V], decompressed_dict)
 
         # Decompress if needed
         to_unpack = (
@@ -236,18 +226,9 @@ class CompressedDict[K, V](MutableMapping[K, V]):
             raw=False,  # Convert to strings
             strict_map_key=False,  # Handle potential key type variations
         )
-        unpacked_dict = (
-            unpacked_dict
-            if isinstance(unpacked_dict, OrderedDict)
-            else OrderedDict[K, V](unpacked_dict)
-        )
-        assert isinstance(unpacked_dict, OrderedDict)
-        return cast(
-            OrderedDict[K, V],
-            unpacked_dict,
-        )
+        return cast(Dict[K, V], unpacked_dict)
 
-    def _get_dict(self) -> OrderedDict[K, V]:
+    def _get_dict(self) -> Dict[K, V]:
         """
         Get the dictionary, deserializing if necessary
 
@@ -265,7 +246,7 @@ class CompressedDict[K, V](MutableMapping[K, V]):
         if self._storage_mode.storage_type == "raw":
             return self._raw_dict
 
-        # For non-raw modes, do not keep deserialized dict
+        # For non-raw modes, do not keep a deserialized dict
         return self._working_dict
 
     def __getitem__(self, key: K) -> V:
@@ -310,12 +291,12 @@ class CompressedDict[K, V](MutableMapping[K, V]):
             # Update the cached properties if the key is in the list
             self._cached_properties[key] = value
 
-    def _update_serialized_dict(self, current_dict: OrderedDict[K, V] | None) -> None:
+    def _update_serialized_dict(self, current_dict: Dict[K, V] | None) -> None:
         if current_dict is None:
             self._cached_properties.clear()
             self._length = 0
             self._serialized_dict = None
-            self._raw_dict = OrderedDict[K, V]()
+            self._raw_dict = {}
             return
 
         if self._properties_to_cache:
@@ -425,7 +406,7 @@ class CompressedDict[K, V](MutableMapping[K, V]):
         """
         return self._get_dict().items()
 
-    def raw_dict(self) -> OrderedDict[K, V]:
+    def raw_dict(self) -> Dict[K, V]:
         """
         Returns the raw dictionary.  Deserializes if necessary.
         Note that this dictionary preserves the python types so it is not FHIR friendly.
@@ -442,7 +423,7 @@ class CompressedDict[K, V](MutableMapping[K, V]):
             # in the self._working_dict to keep memory low
             return self.create_working_dict()
 
-    def dict(self) -> OrderedDict[K, V]:
+    def dict(self) -> Dict[K, V]:
         """
         Convert to a FHIR friendly dictionary where the python types like datetime are converted to string versions
         For example, datetime will be represented as a iso format string per FHIR instead of a python datetime object.
@@ -451,17 +432,14 @@ class CompressedDict[K, V](MutableMapping[K, V]):
             FHIR friendly dictionary
         """
         return cast(
-            OrderedDict[K, V],
-            json.loads(
-                self.json(),
-                object_pairs_hook=lambda pairs: OrderedDict(pairs),
-            ),
+            Dict[K, V],
+            json.loads(self.json()),
         )
 
     def json(self) -> str:
         """Convert the resource to a JSON string."""
 
-        raw_dict: OrderedDict[K, V] = self.raw_dict()
+        raw_dict: Dict[K, V] = self.raw_dict()
 
         return json.dumps(obj=raw_dict, cls=FhirJSONEncoder)
 
@@ -485,7 +463,7 @@ class CompressedDict[K, V](MutableMapping[K, V]):
         )
 
     def replace(
-        self, *, value: Dict[K, V] | OrderedDict[K, V]
+        self, *, value: Dict[K, V]
     ) -> "CompressedDict[K, V]":
         """
         Replace the current dictionary with a new one
@@ -500,10 +478,7 @@ class CompressedDict[K, V](MutableMapping[K, V]):
             self.clear()
             return self
 
-        new_dict: OrderedDict[K, V] = (
-            value if isinstance(value, OrderedDict) else OrderedDict[K, V](value)
-        )
-        self._update_serialized_dict(current_dict=new_dict)
+        self._update_serialized_dict(current_dict=value)
         return self
 
     def clear(self) -> None:
@@ -523,22 +498,17 @@ class CompressedDict[K, V](MutableMapping[K, V]):
             Whether the dictionaries are equal in keys and values
         """
         # If other is not a dictionary-like object, return False
-        if not isinstance(other, (CompressedDict, dict, OrderedDict)):
+        if not isinstance(other, (CompressedDict, dict)):
             return False
 
         # Get the dictionary representation of self
         self_dict = self.dict()
 
-        # If other is a CompressedDict, use its _get_dict() method
+        # If other is a CompressedDict, use its dict() method
         if isinstance(other, CompressedDict):
             other_dict = other.dict()
         else:
-            # If other is a plain dict, use it directly
-            if isinstance(other, OrderedDict):
-                # If other is an OrderedDict, use it directly
-                other_dict = other
-            else:
-                other_dict = OrderedDict[K, V](other)
+            other_dict = other
 
         # Compare keys and values
         # Check that all keys in both dictionaries match exactly
@@ -663,7 +633,7 @@ class CompressedDict[K, V](MutableMapping[K, V]):
         Returns:
             Plain dictionary
         """
-        return OrderedDictToDictConverter.convert(self.raw_dict())
+        return self.raw_dict()
 
     @classmethod
     def from_json(cls, json_str: str) -> "CompressedDict[K, V]":
@@ -673,7 +643,7 @@ class CompressedDict[K, V](MutableMapping[K, V]):
         :param json_str: The JSON string to convert.
         :return: A FhirResource object.
         """
-        data = TypePreservationSerializer.deserialize(json_str)
+        data = TypePreservationSerializer.deserialize(json_str, use_ordered_dict=False)
         return cls.from_dict(data)
 
     @classmethod

--- a/compressedfhir/utilities/compressed_dict/v1/compressed_dict.py
+++ b/compressedfhir/utilities/compressed_dict/v1/compressed_dict.py
@@ -462,9 +462,7 @@ class CompressedDict[K, V](MutableMapping[K, V]):
             + ")"
         )
 
-    def replace(
-        self, *, value: Dict[K, V]
-    ) -> "CompressedDict[K, V]":
+    def replace(self, *, value: Dict[K, V]) -> "CompressedDict[K, V]":
         """
         Replace the current dictionary with a new one
 

--- a/compressedfhir/utilities/compressed_dict/v1/test/test_compressed_dict.py
+++ b/compressedfhir/utilities/compressed_dict/v1/test/test_compressed_dict.py
@@ -26,7 +26,7 @@ class TestCompressedDict:
         assert cd._storage_mode.storage_type == "raw"
 
     def test_init_with_dict(self) -> None:
-        """Test initialization with initial dictionary"""
+        """Test initialization with an initial dictionary"""
         initial_data = {"a": 1, "b": 2, "c": 3}
         cd = CompressedDict(
             initial_dict=initial_data,
@@ -465,3 +465,65 @@ def test_nested_dict_with_datetime() -> None:
 
     assert plain_dict["period"]["start"] == nested_dict["period"]["start"]  # type: ignore[index]
     assert plain_dict == nested_dict
+
+
+def test_accepts_ordered_dict_input() -> None:
+    """Test that CompressedDict accepts OrderedDict as input for backward compatibility."""
+    from collections import OrderedDict
+
+    ordered_data: OrderedDict[str, Any] = OrderedDict()
+    ordered_data["z"] = 1
+    ordered_data["a"] = 2
+    ordered_data["m"] = 3
+
+    cd = CompressedDict(
+        initial_dict=ordered_data,
+        storage_mode=CompressedDictStorageMode(storage_type="raw"),
+        properties_to_cache=[],
+    )
+
+    with cd.transaction():
+        assert cd["z"] == 1
+        assert cd["a"] == 2
+        assert cd["m"] == 3
+        # Order should be preserved
+        assert list(cd.keys()) == ["z", "a", "m"]
+
+
+def test_dict_returns_regular_dict() -> None:
+    """Test that dict() returns a regular dict (not OrderedDict) but preserves order."""
+    from collections import OrderedDict
+
+    initial_data = {"z": 1, "a": 2, "m": 3}
+    cd = CompressedDict(
+        initial_dict=initial_data,
+        storage_mode=CompressedDictStorageMode(storage_type="raw"),
+        properties_to_cache=[],
+    )
+
+    result = cd.dict()
+
+    # Should be a dict, not OrderedDict
+    assert type(result) is dict
+    assert not isinstance(result, OrderedDict)
+    # Order should be preserved
+    assert list(result.keys()) == ["z", "a", "m"]
+
+
+def test_raw_dict_returns_regular_dict() -> None:
+    """Test that raw_dict() returns a regular dict."""
+    from collections import OrderedDict
+
+    initial_data = {"x": 1, "y": 2}
+    cd = CompressedDict(
+        initial_dict=initial_data,
+        storage_mode=CompressedDictStorageMode(storage_type="compressed"),
+        properties_to_cache=[],
+    )
+
+    result = cd.raw_dict()
+
+    # Should be a dict, not OrderedDict
+    assert type(result) is dict
+    assert not isinstance(result, OrderedDict)
+    assert result == {"x": 1, "y": 2}

--- a/compressedfhir/utilities/json_helpers.py
+++ b/compressedfhir/utilities/json_helpers.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, cast, Union, Optional, OrderedDict, overload
+from typing import Any, Dict, List, cast, Union, Optional
 from datetime import datetime, date
 
 import orjson
@@ -57,69 +57,9 @@ class FhirClientJsonHelpers:
             }
 
     @staticmethod
-    @overload
-    def remove_empty_elements_from_ordered_dict(
-        d: List[OrderedDict[str, Any]],
-    ) -> List[OrderedDict[str, Any]]: ...
-
-    @staticmethod
-    @overload
-    def remove_empty_elements_from_ordered_dict(
-        d: OrderedDict[str, Any],
-    ) -> OrderedDict[str, Any]: ...
-
-    @staticmethod
-    def remove_empty_elements_from_ordered_dict(
-        d: List[OrderedDict[str, Any]] | OrderedDict[str, Any],
-    ) -> List[OrderedDict[str, Any]] | OrderedDict[str, Any]:
-        """
-        Recursively remove empty lists, empty dicts, or None elements from a dictionary
-        or a list of dictionaries
-        :param d: dictionary or list of dictionaries
-        :return: dictionary or list of dictionaries
-        """
-
-        def empty(x: Any) -> bool:
-            # Check if the input is None, an empty list, an empty dict, or an empty string
-            return (
-                x is None
-                or x == []
-                or x == {}
-                or (isinstance(x, str) and x.strip() == "")
-            )
-
-        if not isinstance(d, (OrderedDict, list, Dict)):
-            return d
-        elif isinstance(d, list):
-            return [
-                v
-                for v in (
-                    FhirClientJsonHelpers.remove_empty_elements_from_ordered_dict(v)
-                    for v in d
-                )
-                if not empty(v)
-            ]
-        else:
-            return OrderedDict[str, Any](
-                {
-                    k: v
-                    for k, v in (
-                        (
-                            k,
-                            FhirClientJsonHelpers.remove_empty_elements_from_ordered_dict(
-                                v
-                            ),
-                        )
-                        for k, v in d.items()
-                    )
-                    if not empty(v)
-                }
-            )
-
-    @staticmethod
     def convert_dict_to_fhir_json(dict_: Dict[str, Any]) -> str:
         """
-        Returns dictionary as json string
+        Returns dictionary as JSON string
 
 
         :return:
@@ -171,7 +111,7 @@ class FhirClientJsonHelpers:
         Safely load JSON with type flexibility
         """
         try:
-            # Converts input to appropriate type if needed
+            # Converts input to the appropriate type if needed
             if isinstance(json_input, str):
                 json_input = json_input.encode("utf-8")
 

--- a/compressedfhir/utilities/json_helpers.py
+++ b/compressedfhir/utilities/json_helpers.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, cast, Union, Optional
+from typing import Any, Dict, List, Union, Optional, overload
 from datetime import datetime, date
 
 import orjson
@@ -17,6 +17,18 @@ class FhirClientJsonHelpers:
         if isinstance(obj, (datetime, date)):
             return obj.isoformat()
         return str(obj)
+
+    @overload
+    @staticmethod
+    def remove_empty_elements(
+        d: Dict[str, Any],
+    ) -> Dict[str, Any]: ...
+
+    @overload
+    @staticmethod
+    def remove_empty_elements(
+        d: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]: ...
 
     @staticmethod
     def remove_empty_elements(
@@ -42,7 +54,7 @@ class FhirClientJsonHelpers:
             return d
         elif isinstance(d, list):
             return [
-                cast(Dict[str, Any], v)
+                v
                 for v in (FhirClientJsonHelpers.remove_empty_elements(v) for v in d)
                 if not empty(v)
             ]
@@ -64,8 +76,8 @@ class FhirClientJsonHelpers:
 
         :return:
         """
-        instance_variables: Dict[str, Any] = cast(
-            Dict[str, Any], FhirClientJsonHelpers.remove_empty_elements(dict_)
+        instance_variables: Dict[str, Any] = (
+            FhirClientJsonHelpers.remove_empty_elements(dict_)
         )
 
         instance_variables_text: str = json.dumps(

--- a/compressedfhir/utilities/json_serializers/type_preservation_serializer.py
+++ b/compressedfhir/utilities/json_serializers/type_preservation_serializer.py
@@ -35,6 +35,7 @@ class TypePreservationSerializer:
         cls,
         json_str: str,
         custom_decoders: Dict[str, Callable[[Any], Any]] | None = None,
+        use_ordered_dict: bool = True,
         **kwargs: Any,
     ) -> Any:
         """
@@ -43,6 +44,7 @@ class TypePreservationSerializer:
         Args:
             json_str: JSON string to deserialize
             custom_decoders: Optional additional custom decoders
+            use_ordered_dict: Whether to use OrderedDict for deserialized dicts
             kwargs: Additional JSON loads arguments
 
         Returns:
@@ -51,7 +53,7 @@ class TypePreservationSerializer:
         return json.loads(
             json_str,
             object_hook=lambda dct: TypePreservationDecoder.decode(
-                dct, custom_decoders
+                dct, custom_decoders, use_ordered_dict=use_ordered_dict
             ),
             **kwargs,
         )

--- a/compressedfhir/utilities/test/test_json_helpers.py
+++ b/compressedfhir/utilities/test/test_json_helpers.py
@@ -34,33 +34,6 @@ class TestFhirClientJsonHelpers:
         expected_list: List[Dict[str, Any]] = [{"a": 1}, {"d": "test"}]
         assert FhirClientJsonHelpers.remove_empty_elements(input_list) == expected_list
 
-    def test_remove_empty_elements_from_ordered_dict(self) -> None:
-        from collections import OrderedDict
-
-        # Test OrderedDict removal
-        input_dict = OrderedDict(
-            [("a", 1), ("b", ""), ("c", None), ("d", []), ("e", {}), ("f", [1, 2, 3])]
-        )
-        expected_dict = OrderedDict([("a", 1), ("f", [1, 2, 3])])
-        result: List[OrderedDict[str, Any]] | OrderedDict[str, Any] = (
-            FhirClientJsonHelpers.remove_empty_elements_from_ordered_dict(input_dict)
-        )
-        assert result == expected_dict
-
-        # Test list of OrderedDicts
-        input_list: List[OrderedDict[str, Any]] = [
-            OrderedDict([("a", 1), ("b", None)]),
-            OrderedDict([("c", []), ("d", "test")]),
-            OrderedDict([("e", {})]),
-        ]
-        expected_list: List[OrderedDict[str, Any]] = [
-            OrderedDict([("a", 1)]),
-            OrderedDict([("d", "test")]),
-        ]
-        result = FhirClientJsonHelpers.remove_empty_elements_from_ordered_dict(
-            input_list
-        )
-        assert result == expected_list
 
     def test_convert_dict_to_fhir_json(self) -> None:
         input_dict = {"name": "John Doe", "age": 30, "address": None, "hobbies": []}

--- a/compressedfhir/utilities/test/test_json_helpers.py
+++ b/compressedfhir/utilities/test/test_json_helpers.py
@@ -34,7 +34,6 @@ class TestFhirClientJsonHelpers:
         expected_list: List[Dict[str, Any]] = [{"a": 1}, {"d": "test"}]
         assert FhirClientJsonHelpers.remove_empty_elements(input_list) == expected_list
 
-
     def test_convert_dict_to_fhir_json(self) -> None:
         input_dict = {"name": "John Doe", "age": 30, "address": None, "hobbies": []}
         result = FhirClientJsonHelpers.convert_dict_to_fhir_json(input_dict)


### PR DESCRIPTION
This pull request refactors the FHIR bundle and related classes to remove the use of `OrderedDict` in favor of standard Python `dict`. The changes simplify type annotations, method signatures, and internal logic, making the codebase more consistent and easier to maintain. The update also standardizes the removal of empty elements from dictionaries, and eliminates unnecessary imports and conversions.

Key changes include:

**Removal of `OrderedDict` usage and type annotations:**
- Replaced all `OrderedDict` type hints and imports with standard `dict` in files such as `fhir_bundle.py`, `fhir_bundle_entry.py`, `fhir_bundle_entry_request.py`, `fhir_bundle_entry_response.py`, `fhir_bundle_entry_search.py`, `fhir_identifier.py`, `fhir_link.py`, `fhir_meta.py`, `fhir_resource.py`, and `fhir_resource_map.py`. This includes constructor arguments, method return types, and variable declarations. [[1]](diffhunk://#diff-342f2280c5eb0a1730362f4cba979516adaff80375259715376a4bb42facbde9L3-R3) [[2]](diffhunk://#diff-e3a53603c8450ad2298b36a8aee0c0620e3c330a0d9216e1775a2cd595c8f470L3-R3) [[3]](diffhunk://#diff-2c4d10b4de46a511a562d1aa12efe7484babb08dc26bc3b3d935b61b9f5e6d37L2-R2) [[4]](diffhunk://#diff-f6a6fe959b6b311980329addc209597ccebc69ac74250a3bea4105556b6332fdL2-R2) [[5]](diffhunk://#diff-cb1ffbd8b1d360f9a5a720cdf34dc3fbf2673ce9df7b2a011664ce6a83b9151cL2-R2) [[6]](diffhunk://#diff-de5ba586c501d567a0aa97a9112929adbdfb841ea635a9efbcf8f59075a47467L2-R2) [[7]](diffhunk://#diff-adb52e868e79c0e724ada60020154a2d33bf3515ce89d2f74c93f0a44cb8b3f6L2-R2) [[8]](diffhunk://#diff-c0afe9b2bce1aa63aa5c65a8e339ef013cfd9b147894779321da11a2520456c6L2-R2) [[9]](diffhunk://#diff-56c6936acd1d45d8242b688233076217732ba6c9316a098f4ce30dd713f2b5ddL3-R3) [[10]](diffhunk://#diff-e41abe0d22aad3e2d1671bc4b3dfc6ab5a7834ba92008ba76bcca3c16f1694eaL11)

**Simplification of dictionary creation and conversion:**
- Updated all `dict()` methods in relevant classes to use standard dictionaries instead of `OrderedDict`, and removed unnecessary conversions from `OrderedDict` to `dict`. [[1]](diffhunk://#diff-342f2280c5eb0a1730362f4cba979516adaff80375259715376a4bb42facbde9L71-R72) [[2]](diffhunk://#diff-e3a53603c8450ad2298b36a8aee0c0620e3c330a0d9216e1775a2cd595c8f470L141-R142) [[3]](diffhunk://#diff-2c4d10b4de46a511a562d1aa12efe7484babb08dc26bc3b3d935b61b9f5e6d37L30-R42) [[4]](diffhunk://#diff-f6a6fe959b6b311980329addc209597ccebc69ac74250a3bea4105556b6332fdL30-R42) [[5]](diffhunk://#diff-cb1ffbd8b1d360f9a5a720cdf34dc3fbf2673ce9df7b2a011664ce6a83b9151cL24-R40) [[6]](diffhunk://#diff-de5ba586c501d567a0aa97a9112929adbdfb841ea635a9efbcf8f59075a47467L31-R48) [[7]](diffhunk://#diff-adb52e868e79c0e724ada60020154a2d33bf3515ce89d2f74c93f0a44cb8b3f6L25-R32) [[8]](diffhunk://#diff-c0afe9b2bce1aa63aa5c65a8e339ef013cfd9b147894779321da11a2520456c6L20-R21) [[9]](diffhunk://#diff-56c6936acd1d45d8242b688233076217732ba6c9316a098f4ce30dd713f2b5ddL157-R159) [[10]](diffhunk://#diff-e41abe0d22aad3e2d1671bc4b3dfc6ab5a7834ba92008ba76bcca3c16f1694eaL39-R43)

**Standardization of empty element removal:**
- Replaced calls to `remove_empty_elements_from_ordered_dict` with `remove_empty_elements` throughout the codebase, reflecting the move away from `OrderedDict`. [[1]](diffhunk://#diff-342f2280c5eb0a1730362f4cba979516adaff80375259715376a4bb42facbde9L93-R88) [[2]](diffhunk://#diff-e3a53603c8450ad2298b36a8aee0c0620e3c330a0d9216e1775a2cd595c8f470L155-R160) [[3]](diffhunk://#diff-2c4d10b4de46a511a562d1aa12efe7484babb08dc26bc3b3d935b61b9f5e6d37L30-R42) [[4]](diffhunk://#diff-f6a6fe959b6b311980329addc209597ccebc69ac74250a3bea4105556b6332fdL30-R42) [[5]](diffhunk://#diff-cb1ffbd8b1d360f9a5a720cdf34dc3fbf2673ce9df7b2a011664ce6a83b9151cL24-R40) [[6]](diffhunk://#diff-de5ba586c501d567a0aa97a9112929adbdfb841ea635a9efbcf8f59075a47467L31-R48) [[7]](diffhunk://#diff-adb52e868e79c0e724ada60020154a2d33bf3515ce89d2f74c93f0a44cb8b3f6L25-R32) [[8]](diffhunk://#diff-c0afe9b2bce1aa63aa5c65a8e339ef013cfd9b147894779321da11a2520456c6L36-R36) [[9]](diffhunk://#diff-56c6936acd1d45d8242b688233076217732ba6c9316a098f4ce30dd713f2b5ddL157-R159)

**Cleanup of imports and class methods:**
- Removed unused imports and class references related to `OrderedDict` and associated converter utilities. [[1]](diffhunk://#diff-342f2280c5eb0a1730362f4cba979516adaff80375259715376a4bb42facbde9L16-L18) [[2]](diffhunk://#diff-342f2280c5eb0a1730362f4cba979516adaff80375259715376a4bb42facbde9L295-R290)

**Consistency in method signatures and data handling:**
- Updated `from_dict` and related methods to accept only standard dictionaries, further enforcing the removal of `OrderedDict` from the API. [[1]](diffhunk://#diff-342f2280c5eb0a1730362f4cba979516adaff80375259715376a4bb42facbde9L134-R129) [[2]](diffhunk://#diff-e3a53603c8450ad2298b36a8aee0c0620e3c330a0d9216e1775a2cd595c8f470L155-R160) [[3]](diffhunk://#diff-2c4d10b4de46a511a562d1aa12efe7484babb08dc26bc3b3d935b61b9f5e6d37L30-R42) [[4]](diffhunk://#diff-f6a6fe959b6b311980329addc209597ccebc69ac74250a3bea4105556b6332fdL30-R42) [[5]](diffhunk://#diff-cb1ffbd8b1d360f9a5a720cdf34dc3fbf2673ce9df7b2a011664ce6a83b9151cL24-R40) [[6]](diffhunk://#diff-de5ba586c501d567a0aa97a9112929adbdfb841ea635a9efbcf8f59075a47467L31-R48) [[7]](diffhunk://#diff-adb52e868e79c0e724ada60020154a2d33bf3515ce89d2f74c93f0a44cb8b3f6L46-R46)

These changes modernize the codebase and reduce complexity, making it more maintainable and Pythonic.